### PR TITLE
[ASD] String Matching - fix computeLPSArray

### DIFF
--- a/Algoritma dan Struktur Data/10 - String Matching/StringMatcher.java
+++ b/Algoritma dan Struktur Data/10 - String Matching/StringMatcher.java
@@ -58,11 +58,10 @@ public class StringMatcher {
         int[] lps = new int[patternLen];
 
         int curLen = 0;
-        int i = 1;
 
         lps[0] = 0;
 
-        for (i=1 ; i<patternLen ; i++){
+        for (int i=1 ; i<patternLen ; i++){
             if (pattern.charAt(i) == pattern.charAt(curLen)){
                 curLen++;
                 lps[i] = curLen;
@@ -71,7 +70,7 @@ public class StringMatcher {
                 while ((curLen > 0) && (pattern.charAt(i) != pattern.charAt(curLen))){
                     curLen = lps[curLen-1];
                 }
-                if (curLen > 0){
+                if (pattern.charAt(i) == pattern.charAt(curLen)){
                     curLen++;
                     lps[i] = curLen;
                 }

--- a/Algoritma dan Struktur Data/10 - String Matching/StringMatcher.java
+++ b/Algoritma dan Struktur Data/10 - String Matching/StringMatcher.java
@@ -5,10 +5,10 @@ public class StringMatcher {
 
         boolean found = false;
 
-        for (int i=0 ; i<textLen ; i++){
+        for (int i=0 ; i+patternLen <= textLen ; i++){
             boolean current_found = true;
             for (int j=0 ; j<patternLen ; j++){
-                if ((i+j >= textLen) || (text.charAt(i+j) != pattern.charAt(j))){
+                if (text.charAt(i+j) != pattern.charAt(j)){
                     current_found = false;
                     break;
                 }
@@ -36,16 +36,16 @@ public class StringMatcher {
         int j=0;
 
         for (int i=0 ; i<textLen ; i++){
-            if ((j < patternLen) && (text.charAt(i) == pattern.charAt(j))){
+            while ((j > 0) && (text.charAt(i) != pattern.charAt(j))) {
+                j = lps[j-1];
+            }
+            if (text.charAt(i) == pattern.charAt(j)){
                 j++;
                 if (j == patternLen){
                     found = true;
                     System.out.println("Found pattern at index " + (i - j + 1) + " using KMP.");
+                    j = lps[j-1];
                 }
-            }
-            else if (j > 0){
-                j = lps[j-1];
-                i--; // it will be incremented in next iteration
             }
         }
 
@@ -62,18 +62,12 @@ public class StringMatcher {
         lps[0] = 0;
 
         for (int i=1 ; i<patternLen ; i++){
+            while ((curLen > 0) && (pattern.charAt(i) != pattern.charAt(curLen))){
+                curLen = lps[curLen-1];
+            }
             if (pattern.charAt(i) == pattern.charAt(curLen)){
                 curLen++;
                 lps[i] = curLen;
-            }
-            else{
-                while ((curLen > 0) && (pattern.charAt(i) != pattern.charAt(curLen))){
-                    curLen = lps[curLen-1];
-                }
-                if (pattern.charAt(i) == pattern.charAt(curLen)){
-                    curLen++;
-                    lps[i] = curLen;
-                }
             }
         }
 

--- a/Algoritma dan Struktur Data/10 - String Matching/StringMatcherMain.java
+++ b/Algoritma dan Struktur Data/10 - String Matching/StringMatcherMain.java
@@ -9,7 +9,8 @@ public class StringMatcherMain {
         text = sc.nextLine();
 
         System.out.println("Input pattern: ");
-        pattern = sc.nextLine();        
+        do pattern = sc.nextLine();
+        while (pattern.equals(""));
         
         StringMatcher.naive(text, pattern);
         StringMatcher.kmp(text, pattern);


### PR DESCRIPTION
Prior to this PR, failed when `pattern = "abcababab"` or `pattern` is an empty string.